### PR TITLE
87 - set env NODE_ENV to fix the deployment issue

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,4 +1,5 @@
-require("dotenv").config(); //.env file in main folder
+if (process.env.NODE_ENV === 'dev') require('dotenv').config(); //.env file in main folder
+
 // NOTE: feels bad? react having access to .env
 
 /* 
@@ -6,7 +7,7 @@ require("dotenv").config(); //.env file in main folder
 */
 
 const SERVER_PORT = process.env.PORT || 8080;
-const SERVER_HOSTNAME = process.SERVER_HOSTNAME || "localhost";
+const SERVER_HOSTNAME = process.SERVER_HOSTNAME || 'localhost';
 
 const MONGO_CONF = {
     useNewUrlParser: true,

--- a/server/env.js
+++ b/server/env.js
@@ -1,0 +1,8 @@
+// pre-loading env to set it as dev or production
+
+/* 
+    this may fix the deployment problem as
+    the dotenv package is not set as the field
+*/
+
+process.env.NODE_ENV = 'dev';

--- a/server/package.json
+++ b/server/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "server",
-  "version": "1.0.0",
-  "description": "",
-  "main": "server.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "serve": "node server.js",
-    "start": "nodemon"
-  },
-  "author": "",
-  "license": "ISC",
-  "dependencies": {
-    "bcrypt": "^5.0.1",
-    "cors": "^2.8.5",
-    "express": "^4.17.1",
-    "express-jwt": "^6.0.0",
-    "express-validator": "^6.11.1",
-    "jsonwebtoken": "^8.5.1",
-    "mongoose": "^5.12.5"
-  },
-  "devDependencies": {
-    "dotenv": "^8.2.0",
-    "nodemon": "^2.0.7",
-    "prettier": "^2.3.0"
-  }
+    "name": "server",
+    "version": "1.0.0",
+    "description": "",
+    "main": "server.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "serve": "node server.js",
+        "start": "nodemon -r ./env.js server.js"
+    },
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "bcrypt": "^5.0.1",
+        "cors": "^2.8.5",
+        "express": "^4.17.1",
+        "express-jwt": "^6.0.0",
+        "express-validator": "^6.11.1",
+        "jsonwebtoken": "^8.5.1",
+        "mongoose": "^5.12.5"
+    },
+    "devDependencies": {
+        "dotenv": "^8.2.0",
+        "nodemon": "^2.0.7",
+        "prettier": "^2.3.0"
+    }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -6,8 +6,6 @@ const logging = require('./config/logging');
 const config = require('./config/config');
 const serverUtils = require('./utils/server.util');
 
-require('dotenv').config();
-
 /**
  * TODO:
  * - set up cors to secure access


### PR DESCRIPTION
## Rationale

This is to fix the deployed site issue

## Problem 

The heroku logs shows that it has trouble finding importing "dotevn" in the config files

This is because dotenv was installed as a dev dependency

> This will need to be also merged straight into `main` to test

## Solution 

- hide the package import behind an environment variable
- change the dev run script to add set dev variable in dev 

## Task Name

- Issue Title #87 
