### PR TITLE
updated react paths

### DIFF
--- a/web/jsconfig.json
+++ b/web/jsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "baseUrl": "src"
+    },
+    "include": ["src"]
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,7 +18,7 @@
                 "@testing-library/jest-dom": "^5.11.9",
                 "@testing-library/react": "^11.2.5",
                 "@testing-library/user-event": "^12.8.3",
-                "axios": "^0.21.1",
+                "axios": "^0.21.4",
                 "prop-types": "^15.7.2",
                 "react": "^17.0.1",
                 "react-dom": "^17.0.1",

--- a/web/src/app/App.jsx
+++ b/web/src/app/App.jsx
@@ -4,8 +4,8 @@ import { useAuth } from "../contexts/authContext";
 
 import "./App.css";
 import UserRoute from "./authWrapper/UserRoute";
-import { Layout } from "../components/layout/Layout";
-import * as Pages from "../pages/Pages";
+import { Layout } from "components/layout/Layout";
+import * as Pages from "pages/Pages";
 
 /* 
     TODO: 

--- a/web/src/app/authWrapper/UserRoute.jsx
+++ b/web/src/app/authWrapper/UserRoute.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Route, Redirect } from "react-router-dom";
-import { useAuth } from "../../contexts/authContext";
+import { useAuth } from "contexts/authContext";
 import axios from "axios";
 
 /* 

--- a/web/src/components/FortAwesome/FortAwesomeIcons.jsx
+++ b/web/src/components/FortAwesome/FortAwesomeIcons.jsx
@@ -12,6 +12,8 @@ import {
 
 /* 
     handling fort awesome icon imports
+
+    Note: is this being used? there are 2 coppies
 */
 
 // free-solid-svg-icons

--- a/web/src/components/footer/Footer.jsx
+++ b/web/src/components/footer/Footer.jsx
@@ -1,6 +1,6 @@
 import styles from "./Footer.style";
 import { Twitter, Facebook, Instagram, LinkedIn } from "@material-ui/icons";
-import wocimage from "../../res/img/woclogo.jpg";
+import wocimage from "res/img/woclogo.jpg";
 
 const Footer = () => {
     const classes = styles();

--- a/web/src/components/fortAwesome/FortAwesomeIcons.jsx
+++ b/web/src/components/fortAwesome/FortAwesomeIcons.jsx
@@ -12,6 +12,8 @@ import {
 
 /* 
     handling fort awesome icon imports
+
+    NOTE: is this being used?
 */
 
 // free-solid-svg-icons

--- a/web/src/components/layout/Layout.jsx
+++ b/web/src/components/layout/Layout.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import NavBar from "../navbar/NavBar";
-import Footer from "../footer/Footer";
+import NavBar from "components/navbar/NavBar";
+import Footer from "components/footer/Footer";
 
 import { Container } from "@material-ui/core";
 /* 

--- a/web/src/components/navbar/NavBar.jsx
+++ b/web/src/components/navbar/NavBar.jsx
@@ -2,8 +2,8 @@ import React from "react";
 import { AppBar, Toolbar, Button, Box } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/";
 import { Link } from "react-router-dom";
-import logo from "../../res/img/2.png";
-import { useAuth } from "../../contexts/authContext";
+import logo from "res/img/2.png";
+import { useAuth } from "contexts/authContext";
 
 /* 
     Handing main navigation bar for site

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -2,12 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 import reportWebVitals from "./reportWebVitals";
 
-import "./index.css";
-import FortAwesomeIcons from "./components/FortAwesome/FortAwesomeIcons";
+import "index.css";
+import FortAwesomeIcons from "components/FortAwesome/FortAwesomeIcons";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import AppWrapper from "./app/AppWrapper";
+import AppWrapper from "app/AppWrapper";
 import { ThemeProvider } from "@material-ui/core";
-import Theme from "./Theme";
+import Theme from "Theme";
 
 ReactDOM.render(
     // <React.StrictMode>

--- a/web/src/pages/landing/Landing.jsx
+++ b/web/src/pages/landing/Landing.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 import { Container, Grid, Paper, Button } from "@material-ui/core";
-import landingSvg from "../../res/img/women.svg";
+import landingSvg from "res/img/women.svg";
 import styles from "./Landing.style";
 import cardData from "./cardData";
 

--- a/web/src/pages/landing/Landing.style.jsx
+++ b/web/src/pages/landing/Landing.style.jsx
@@ -1,6 +1,6 @@
 import { makeStyles } from "@material-ui/core/styles";
 // TODO: change this to font in Index
-import "../../components/navbar/NavBar.css";
+import "components/navbar/NavBar.css";
 
 const styles = makeStyles((theme) => ({
     root: {

--- a/web/src/pages/landing/cardData.js
+++ b/web/src/pages/landing/cardData.js
@@ -1,7 +1,7 @@
-import mentoringSvg from "./../../res/img/mentoring2.svg";
-import eventSvg from "../../res/img/events5.svg";
-import chatroomSvg from "../../res/img/chatrooms.svg";
-import onlinecourseSvg from "../../res/img/onlinecourses.svg";
+import mentoringSvg from "res/img/mentoring2.svg";
+import eventSvg from "res/img/events5.svg";
+import chatroomSvg from "res/img/chatrooms.svg";
+import onlinecourseSvg from "res/img/onlinecourses.svg";
 
 const cardData = [
     {   id: "1",

--- a/web/src/pages/login/Login.jsx
+++ b/web/src/pages/login/Login.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Link as RouterLink, Redirect } from "react-router-dom";
 import axios from "axios";
-import { useAuth } from "../../contexts/authContext";
+import { useAuth } from "contexts/authContext";
 
 import {
     Avatar,

--- a/web/src/pages/signUp/SignUp.jsx
+++ b/web/src/pages/signUp/SignUp.jsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
-import { checkIsFormValid, validateInput } from "../../utils/formUtils";
 import { Link as RouterLink, useHistory } from "react-router-dom";
+import axios from "axios";
+
+import { checkIsFormValid, validateInput } from "utils/formUtils";
+import Copyright from "components/copyright/Copyright";
+
 import Avatar from "@material-ui/core/Avatar";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
@@ -10,12 +14,10 @@ import Link from "@material-ui/core/Link";
 import Grid from "@material-ui/core/Grid";
 import Box from "@material-ui/core/Box";
 import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
-import { makeStyles } from "@material-ui/core/styles";
 import Container from "@material-ui/core/Container";
-import Copyright from "../../components/copyright/Copyright";
-import { FormHelperText } from "@material-ui/core";
-import { Typography } from "@material-ui/core";
-import axios from "axios";
+import { Typography, FormHelperText } from "@material-ui/core";
+
+import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
     paper: {

--- a/web/src/pages/userDashboard/UserDashboard.jsx
+++ b/web/src/pages/userDashboard/UserDashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
-import { LayoutUserDashboard } from "../../components/layout/Layout";
+import { LayoutUserDashboard } from "components/layout/Layout";
 
 import UserProfile from "./userprofile/UserProfile";
 import UserEvents from "./userevents/UserEvents";

--- a/web/src/pages/userDashboard/userevents/UserEvents.jsx
+++ b/web/src/pages/userDashboard/userevents/UserEvents.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import random from "../../../../src/res/img/events5.svg";
+import random from "res/img/events5.svg";
 import axios from "axios";
 
 import {


### PR DESCRIPTION
## Changes

Minor config change for React, Import can now use absolute path from the folder `src`

previously importing code from other folder requires you to traverse through multiple layer of folders to get what you want

Now you import what you want in a cleaner and easier to read way

e.g
```js
import wocimage from "../../res/img/woclogo.jpg";      // before
import wocimage from "res/img/woclogo.jpg";            // now

import { useAuth } from "../../contexts/authContext";  // before
import { useAuth } from "contexts/authContext";        // now
```

## Issue Fix

fixes issue #93 