### PR TITLE
update get user data to get userID from token

### DIFF
--- a/server/controller/user.controller.js
+++ b/server/controller/user.controller.js
@@ -1,11 +1,14 @@
-const User = require('../models/user.model');
+ const User = require('../models/user.model');
 const logging = require('../config/logging');
 
 const NAMESPACE = "CTR_USER"
 
 // TODO: add validation
 const getUser = async (req, res) => {
-    const user = await User.findById(req.body.id);
+    const token = req.get("Authorization").split(" ")[1];
+    const userID = require("jsonwebtoken").decode(token).id;
+    const user = await User.findById(userID);
+
     if(user) {
         return res.status(200).json(user);
     } else {


### PR DESCRIPTION
## Small patch

It was noticed by Pablo earlier, the latest merge broke how user data is fetched

Most updated change `/api/user` assumed that it was getting the userID via request body and that was wrong.
`api/user` is only used in the 
- auth containers (may need reviews to be changed)
- main dashboard to get user data

Both of these location would be only available to a logged in user 
Therefore, every call would contain the auth token,

so the endpoint is now changed to grab the userID from the jwt token instead