### PR TITLE
fix: Mongoose URI Undefined

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,4 +1,4 @@
-if (process.env.NODE_ENV === 'dev') require('dotenv').config(); //.env file in main folder
+if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === undefined) require('dotenv').config(); //.env file in main folder
 
 // NOTE: feels bad? react having access to .env
 


### PR DESCRIPTION
closes #116

## Rationale
Load configs when NODE_ENV is undefined (default value).

## Task Name

## Linting Checklist
- [x] No commented code
- [x] Code Formatted nicely (Prettier)
- [x] PR your own code before you assign reviewers